### PR TITLE
change value outDir to build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,7 +55,7 @@
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "dist" /* Specify an output folder for all emitted files. */,
+    "outDir": "build" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
1. Railway is trying to run node build/index.js, but that file doesn’t exist in your deployed container.
2. Change value for outDir from dist to build