### PR TITLE
♻️ Fix: Move prisma generate to postinstall, clean env

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "tsx watch src/index.ts",
-    "build": "prisma generate && tsc",
+    "build": "tsc",
+    "postinstall": "prisma generate",
     "start": "node build/index.js",
     "dev:local": "dotenv -e .env.local -- tsx watch src/index.ts",
     "dev:supabase": "dotenv -e .env.supabase -- tsx watch src/index.ts"


### PR DESCRIPTION
1. Change build and add postinstall
2. The previous version running prisma generate during pnpm run build, but Railway doesn’t inject the DATABASE_URL environment variable until after build, during the postinstall and start phase.
"scripts": {
  ...
  "build": "prisma generate && tsc",  ❌ <- THIS is the problem
  "start": "node build/index.js"
}
tsc just compiles your TS to JS (build/)

prisma generate runs after DATABASE_URL is injected (and generates a valid client)
