### PR TITLE
🔥 Fix: regenerate Prisma using prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "postinstall": "prisma generate",
+    "prepare": "prisma generate",
     "start": "node build/index.js",
     "dev:local": "dotenv -e .env.local -- tsx watch src/index.ts",
     "dev:supabase": "dotenv -e .env.supabase -- tsx watch src/index.ts"


### PR DESCRIPTION
1. Move prisma generate to "prepare" instead of "postinstall"
> In package.json:
> "scripts": {
>   "build": "tsc",
>   "prepare": "prisma generate",   ✅ ← THIS is better supported in Railway
>   "start": "node build/index.js"
> }
2. Why?
> On Railway, the postinstall hook is not always run at the correct time in the build container.
> The prepare script is guaranteed to run before start and after environment variables are available.
> 
